### PR TITLE
Directory change and implementing JWT-key environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,11 +124,10 @@ COPY --chown=slurm files/slurm/slurmdbd.conf /etc/slurm/slurmdbd.conf
 COPY --chown=slurm files/slurm/slurmrestd.conf /etc/slurm/slurmrestd.conf
 COPY files/supervisord.conf /etc/
 
-RUN chmod 0600 /etc/slurm/slurmdbd.conf \
-    && mkdir /home/slurmrestd/slurm-workdir
+RUN chmod 0600 /etc/slurm/slurmdbd.conf
 
 # Mark externally mounted volumes
-VOLUME ["/var/lib/mysql", "/var/lib/slurmd", "/var/spool/slurm", "/var/log/slurm", "/home/slurmrestd/slurm-workdir"]
+VOLUME ["/var/lib/mysql", "/var/lib/slurmd", "/var/spool/slurm", "/var/log/slurm", "/home/slurmrestd"]
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -85,17 +85,18 @@ then
     error_with_msg "MariaDB did not stop"
 fi
 
+jwt_secret_dir="/etc/slurm/jwt/jwt_hs256.key"
 if [ "$JWT_SECRET" ]
 then
     echo "- JWT secret variable found, writing..."
-    echo "$JWT_SECRET" > /etc/slurm/jwt/jwt_hs256.key
+    echo "$JWT_SECRET" > $jwt_secret_dir
 else
     echo "- No JWT secret variable found, generating JWT key"
-    dd if=/dev/urandom bs=32 count=1 >/etc/slurm/jwt/jwt_hs256.key
+    dd if=/dev/urandom bs=32 count=1 >$jwt_secret_dir
 fi
 
-chown slurm:slurm /etc/slurm/jwt/jwt_hs256.key
-chmod 0600 /etc/slurm/jwt/jwt_hs256.key
+chown slurm:slurm $jwt_secret_dir
+chmod 0600 $jwt_secret_dir
 
 echo "- Starting supervisord process manager"
 /usr/bin/supervisord --configuration /etc/supervisord.conf

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -85,8 +85,15 @@ then
     error_with_msg "MariaDB did not stop"
 fi
 
-echo "- Generating JWT key"
-dd if=/dev/urandom bs=32 count=1 >/etc/slurm/jwt/jwt_hs256.key
+if [ "$JWT_SECRET" ]
+then
+    echo "- JWT secret variable found, writing..."
+    echo "$JWT_SECRET" > /etc/slurm/jwt/jwt_hs256.key
+else
+    echo "- No JWT secret variable found, generating JWT key"
+    dd if=/dev/urandom bs=32 count=1 >/etc/slurm/jwt/jwt_hs256.key
+fi
+
 chown slurm:slurm /etc/slurm/jwt/jwt_hs256.key
 chmod 0600 /etc/slurm/jwt/jwt_hs256.key
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -85,18 +85,18 @@ then
     error_with_msg "MariaDB did not stop"
 fi
 
-jwt_secret_dir="/etc/slurm/jwt/jwt_hs256.key"
+jwt_secret_file="/etc/slurm/jwt/jwt_hs256.key"
 if [ "$JWT_SECRET" ]
 then
     echo "- JWT secret variable found, writing..."
-    echo "$JWT_SECRET" > $jwt_secret_dir
+    echo "$JWT_SECRET" > $jwt_secret_file
 else
     echo "- No JWT secret variable found, generating JWT key"
-    dd if=/dev/urandom bs=32 count=1 >$jwt_secret_dir
+    dd if=/dev/urandom bs=32 count=1 >$jwt_secret_file
 fi
 
-chown slurm:slurm $jwt_secret_dir
-chmod 0600 $jwt_secret_dir
+chown slurm:slurm $jwt_secret_file
+chmod 0600 $jwt_secret_file
 
 echo "- Starting supervisord process manager"
 /usr/bin/supervisord --configuration /etc/supervisord.conf


### PR DESCRIPTION
Changed volume directory to just point at home directory (as creating a subdirectory still required a chmod command, or changing to the slurmrestd user.

Added a check for a non-empty JWT_SECRET environment variable, which is used in preference to manual generation if found.

Not implemented using this environment variable on UQLE-API-side, but this is in the backlog.