### PR TITLE
Add changes for implementing separate worker nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,165 @@
-.pytest_cache
-.vscode
-__pycache__
-venv
+.venv/
 volumes
 
-venv
-.vscode
-.pytest_cache
-.hypothesis
-__pycache__
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintainted in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+.vscode/
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+uqle.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,6 @@ WORKDIR ${SLURM_HOME}
 
 ARG PYENV_ROOT=${SLURM_HOME}/.pyenv
 
-RUN echo "$SHELL" > output.txt
 RUN echo 'eval "$(pyenv init -)"' >> ${SLURM_HOME}/.bash_profile
 
 RUN echo "export PYENV_ROOT=${PYENV_ROOT}" >> ${SLURM_HOME}/.profile; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,13 @@ LABEL org.opencontainers.image.source="https://github.com/drewsilcock/docker-cen
 ENV PATH "/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin"
 
 # Install common YUM dependency packages
+COPY ./input-yum.conf .
 RUN set -ex \
-    && yum makecache fast \
-    && yum -y install deltarpm epel-release \
-    && yum -y update \
-    && yum -y install \
+    && cat input-yum.conf >> /etc/yum.conf \
+    && yum install deltarpm epel-release \
+    && rm input-yum.conf \
+    && yum upgrade \
+    && yum install \
     autoconf \
     bash-completion \
     bzip2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ ENV PATH "/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin"
 # Install common YUM dependency packages
 RUN set -ex \
     && yum makecache fast \
+    && yum -y install deltarpm epel-release \
     && yum -y update \
-    && yum -y install epel-release \
     && yum -y install \
     autoconf \
     bash-completion \
@@ -71,9 +71,14 @@ ARG SLURM_TAG=slurm-21-08-0-1
 RUN set -ex \
     && git clone -b ${SLURM_TAG} --single-branch --depth=1 https://github.com/SchedMD/slurm.git \
     && pushd slurm \
-    && ./configure --quiet --disable-dependency-tracking --prefix=/usr --sysconfdir=/etc/slurm --enable-load-env-no-login \
-    --with-mysql_config=/usr/bin --libdir=/usr/lib64 \
-    --enable-slurmrestd --with-jwt \
+    && ./configure \
+    --quiet \
+    --prefix=/usr \
+    --sysconfdir=/etc/slurm \
+    --with-mysql_config=/usr/bin \
+    --libdir=/usr/lib64 \
+    --enable-slurmrestd \
+    --with-jwt \
     && make --quiet install \
     && install -D -m644 etc/cgroup.conf.example /etc/slurm/cgroup.conf.example \
     && install -D -m644 etc/slurm.conf.example /etc/slurm/slurm.conf.example \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     slurmctl:
         build: .
         hostname: slurmctl
-        command: "controller"
         stdin_open: true
         tty: true
         ports:
@@ -33,7 +32,6 @@ services:
     slurmd:
         build: .
         hostname: slurmd
-        command: "worker"
         stdin_open: true
         tty: true
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,80 @@
-version: '3'
+version: "3"
 
 services:
-  slurm:
-    build: .
-    hostname: slurmctl
-    stdin_open: true
-    tty: true
-    ports:
-      - "6818:6818"
-      - "6819:6819"
-      - "6820:6820"
-    cap_add:
-      - SYS_PTRACE
-      - SYS_ADMIN
-      - MKNOD
-      - SYS_NICE
-      - SYS_RESOURCE
-    security_opt:
-      - seccomp:unconfined
-      - apparmor:unconfined
-    volumes:
-      - ./volumes/lib:/var/lib/slurmd
-      - ./volumes/spool:/var/spool/slurm
-      - ./volumes/log:/var/log/slurm
-      - ./volumes/db:/var/lib/mysql
-      - ./volumes/jwt:/etc/slurm/jwt
+    slurmctl:
+        build: .
+        hostname: slurmctl
+        command: "controller"
+        stdin_open: true
+        tty: true
+        ports:
+            - "6819:6819"
+            - "6820:6820"
+        cap_add:
+            - SYS_PTRACE
+            - SYS_ADMIN
+            - MKNOD
+            - SYS_NICE
+            - SYS_RESOURCE
+        security_opt:
+            - seccomp:unconfined
+            - apparmor:unconfined
+        volumes:
+            - slurmctl-lib-volume:/var/lib/slurmd
+            - slurmctl-spool-volume:/var/spool/slurm
+            - slurmctl-log-volume:/var/log/slurm
+            - slurmctl-db-volume:/var/lib/mysql
+            - slurmctl-jwt-volume:/etc/slurm/jwt
+            # - slurm-workdir-volume:/home/slurmrestd
+        env_file:
+            - uqle.env
+        environment:
+            - NODE_TYPE=controller
+    slurmd:
+        build: .
+        hostname: slurmd
+        command: "worker"
+        stdin_open: true
+        tty: true
+        ports:
+            - "6818:6818"
+        cap_add:
+            - SYS_PTRACE
+            - SYS_ADMIN
+            - MKNOD
+            - SYS_NICE
+            - SYS_RESOURCE
+        security_opt:
+            - seccomp:unconfined
+            - apparmor:unconfined
+        volumes:
+            - slurmd-lib-volume:/var/lib/slurmd
+            - slurmd-spool-volume:/var/spool/slurm
+            - slurmd-log-volume:/var/log/slurm
+            - slurmd-db-volume:/var/lib/mysql
+            - slurmd-jwt-volume:/etc/slurm/jwt
+        env_file:
+            - uqle.env
+        environment:
+            - NODE_TYPE=worker
+volumes:
+    slurmctl-db-volume:
+        name: "slurmctl-db-volume"
+    slurmctl-log-volume:
+        name: "slurmctl-log-volume"
+    slurmctl-spool-volume:
+        name: "slurmctl-spool-volume"
+    slurmctl-lib-volume:
+        name: "slurmctl-lib-volume"
+    slurmctl-jwt-volume:
+        name: "slurmctl-jwt-volume"
+    slurmd-db-volume:
+        name: "slurmd-db-volume"
+    slurmd-log-volume:
+        name: "slurmd-log-volume"
+    slurmd-spool-volume:
+        name: "slurmd-spool-volume"
+    slurmd-lib-volume:
+        name: "slurmd-lib-volume"
+    slurmd-jwt-volume:
+        name: "slurmd-jwt-volume"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 function error_with_msg {
     if [[ "$count" -eq 0 ]]
     then
@@ -42,49 +41,6 @@ function start_service {
     check_running_status $1
 }
 
-if [ ! -d "/var/lib/mysql/mysql" ]
-then
-    echo "[mysqld]\nskip-host-cache\nskip-name-resolve" > /etc/my.cnf.d/docker.cnf
-    echo "- Initializing database"
-    /usr/bin/mysql_install_db --user=mysql &> /dev/null
-    echo "- Database initialized"
-fi
-
-if [ ! -d "/var/lib/mysql/slurm_acct_db" ]
-then
-    /usr/bin/mysqld_safe &
-
-    for count in {30..0}; do
-        if echo "SELECT 1" | mysql &> /dev/null
-        then
-            break
-        fi
-        echo "- Starting MariaDB to create Slurm account database"
-        sleep 1
-    done
-
-    error_with_msg "MariaDB did not start"
-
-    echo "- Creating Slurm acct database"
-    mysql -NBe "CREATE USER 'slurm'@'localhost' identified by 'password'"
-    mysql -NBe "GRANT ALL ON slurm_acct_db.* to 'slurm'@'localhost' identified by 'password' with GRANT option"
-    mysql -NBe "GRANT ALL ON slurm_acct_db.* to 'slurm'@'slurmctl' identified by 'password' with GRANT option"
-    mysql -NBe "CREATE DATABASE slurm_acct_db"
-    echo "- Slurm acct database created. Stopping MariaDB"
-    killall mysqld
-
-    for count in {30..0}; do
-        if echo "SELECT 1" | mysql &> /dev/null
-        then
-            sleep 1
-        else
-            break
-        fi
-    done
-
-    error_with_msg "MariaDB did not stop"
-fi
-
 jwt_secret_file="/etc/slurm/jwt/jwt_hs256.key"
 if [ "$JWT_SECRET" ]
 then
@@ -98,32 +54,93 @@ fi
 chown slurm:slurm $jwt_secret_file
 chmod 0600 $jwt_secret_file
 
-echo "- Starting supervisord process manager"
-/usr/bin/supervisord --configuration /etc/supervisord.conf
+if [[ "$NODE_TYPE" == "controller" ]]
+then
 
-
-for service in munged mysqld slurmdbd slurmctld slurmd slurmrestd
-do
-    start_service $service
-done
-
-for port in 6817 6818 6819 6820
-do
-    check_port_status $port
-done
-
-echo "- Waiting for the cluster to become available"
-for count in {10..0}; do
-    if ! grep -q "normal.*idle" <(timeout 1 sinfo)
+    if [ ! -d "/var/lib/mysql/mysql" ]
     then
-        sleep 1
-    else
-        break
+        echo "[mysqld]\nskip-host-cache\nskip-name-resolve" > /etc/my.cnf.d/docker.cnf
+        echo "- Initializing database"
+        /usr/bin/mysql_install_db --user=mysql &> /dev/null
+        echo "- Database initialized"
     fi
-done
 
-error_with_msg "Slurm partitions failed to start successfully."
+    if [ ! -d "/var/lib/mysql/slurm_acct_db" ]
+    then
+        /usr/bin/mysqld_safe &
 
-echo "- Cluster is now available"
+        for count in {30..0}; do
+            if echo "SELECT 1" | mysql &> /dev/null
+            then
+                break
+            fi
+            echo "- Starting MariaDB to create Slurm account database"
+            sleep 1
+        done
+
+        error_with_msg "MariaDB did not start"
+
+        echo "- Creating Slurm acct database"
+        mysql -NBe "CREATE USER 'slurm'@'localhost' identified by 'password'"
+        mysql -NBe "GRANT ALL ON slurm_acct_db.* to 'slurm'@'localhost' identified by 'password' with GRANT option"
+        mysql -NBe "GRANT ALL ON slurm_acct_db.* to 'slurm'@'slurmctl' identified by 'password' with GRANT option"
+        mysql -NBe "CREATE DATABASE slurm_acct_db"
+        echo "- Slurm acct database created. Stopping MariaDB"
+        killall mysqld
+
+        for count in {30..0}; do
+            if echo "SELECT 1" | mysql &> /dev/null
+            then
+                sleep 1
+            else
+                break
+            fi
+        done
+
+        error_with_msg "MariaDB did not stop"
+    fi
+
+    echo "- Starting supervisord process manager"
+    /usr/bin/supervisord --configuration /etc/supervisord.conf
+
+
+    for service in munged mysqld slurmdbd slurmctld slurmrestd
+    do
+        start_service $service
+    done
+
+    for port in 6817 6819 6820
+    do
+        check_port_status $port
+    done
+
+    echo "- Waiting for the cluster to become available"
+    for count in {10..0}; do
+        if ! grep -q "normal.*idle" <(timeout 1 sinfo)
+        then
+            sleep 1
+        else
+            break
+        fi
+    done
+
+    error_with_msg "Slurm partitions failed to start successfully."
+
+    echo "- Cluster is now available"
+fi
+
+if [[ "$NODE_TYPE" == "worker" ]]
+then
+
+    echo "- Starting supervisord process manager"
+    /usr/bin/supervisord --configuration /etc/supervisord.conf
+
+    for service in munged slurmd
+    do
+        start_service $service
+    done
+
+fi
 
 exec "$@"
+

--- a/files/slurm/slurm.conf
+++ b/files/slurm/slurm.conf
@@ -53,7 +53,7 @@ KillWait=30
 MinJobAge=300
 MpiDefault=none
 #MpiParams=ports=#-#
-NodeName=c1 NodeHostName=slurmctl NodeAddr=127.0.0.1 RealMemory=1000
+NodeName=c1 NodeHostName=slurmd RealMemory=1000
 #NodeName=c2 NodeHostName=slurmctl NodeAddr=127.0.0.1 RealMemory=1000
 #NodeName=c3 NodeHostName=slurmctl NodeAddr=127.0.0.1 RealMemory=1000 Gres=gpu:titanxp:1
 #NodeName=c4 NodeHostName=slurmctl NodeAddr=127.0.0.1 RealMemory=1000 Gres=gpu:titanxp:1

--- a/input-yum.conf
+++ b/input-yum.conf
@@ -1,0 +1,3 @@
+assumeyes=1
+clean_requirements_on_remove=1
+keepcache=0


### PR DESCRIPTION
- Adding python3 as a yum install, as python3 binary is needed for slurm build, but user-scoped python version is more reliable for using in slurm jobs
- Added pyenv install steps to the slurmrestd user in their HOME directory
- Edited entrypoint to recognise an env variable for the node type
- Changed slurm conf file to expect a worker node
- TODO: work out a new shared space setup for the worker nodes and the host node
    - They can't be the current home directory, because mounting on separate nodes causes conflicts due to the files aready present in the image (dotfiles, .pyenv directory...)
 - Some build flags added to slurm that according to the docs should speed up one-time builds
 - Also added a user-env related flag to configure that appeared to desired behaviour

- Changes have been tested using commands on host node of the form `sbatch --uid=1002 --gid=1002 --export=NONE script`
- **Note:** Of most importance seems to be this `--export` flag and the script having the shebang `#!/bin/bash -l`
    - All other flags, even `--get-user-env` flag, seem to have no effect