### PR TITLE
Use jwt key env var only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,6 +132,7 @@ RUN git clone --depth 1 --branch v2.2.3 https://github.com/pyenv/pyenv.git ${PYE
 
 RUN ${PYENV_ROOT}/bin/pyenv install 3.9.9 && ${PYENV_ROOT}/bin/pyenv global 3.9.9
 
+RUN mkdir ${SLURM_HOME}/shared
 USER root
 WORKDIR /root
 
@@ -142,9 +143,8 @@ COPY --chown=slurm files/slurm/slurmrestd.conf /etc/slurm/slurmrestd.conf
 COPY files/supervisord.conf /etc/
 
 RUN chmod 0600 /etc/slurm/slurmdbd.conf
-
 # Mark externally mounted volumes
-VOLUME ["/var/lib/mysql", "/var/lib/slurmd", "/var/spool/slurm", "/var/log/slurm", "/home/slurmrestd"]
+VOLUME ["/var/lib/mysql", "/var/lib/slurmd", "/var/spool/slurm", "/var/log/slurm", "/home/slurmrestd/shared"]
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   slurmctl:
     build: .
-    image: drew-docker-centos7-slurm:latest
+    image: docker-centos7-slurm:latest
     hostname: slurmctl
     stdin_open: true
     tty: true
@@ -31,7 +31,7 @@ services:
       SLURM_JWT_KEY:
   slurmd:
     build: .
-    image: drew-docker-centos7-slurm:latest
+    image: docker-centos7-slurm:latest
     hostname: slurmd
     stdin_open: true
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3"
 services:
   slurmctl:
     build: .
-    image: docker-centos7-slurm:latest
     hostname: slurmctl
     stdin_open: true
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,78 +1,70 @@
 version: "3"
 
 services:
-    slurmctl:
-        build: .
-        hostname: slurmctl
-        stdin_open: true
-        tty: true
-        ports:
-            - "6819:6819"
-            - "6820:6820"
-        cap_add:
-            - SYS_PTRACE
-            - SYS_ADMIN
-            - MKNOD
-            - SYS_NICE
-            - SYS_RESOURCE
-        security_opt:
-            - seccomp:unconfined
-            - apparmor:unconfined
-        volumes:
-            - slurmctl-lib-volume:/var/lib/slurmd
-            - slurmctl-spool-volume:/var/spool/slurm
-            - slurmctl-log-volume:/var/log/slurm
-            - slurmctl-db-volume:/var/lib/mysql
-            - slurmctl-jwt-volume:/etc/slurm/jwt
-            # - slurm-workdir-volume:/home/slurmrestd
-        env_file:
-            - uqle.env
-        environment:
-            - NODE_TYPE=controller
-    slurmd:
-        build: .
-        hostname: slurmd
-        stdin_open: true
-        tty: true
-        ports:
-            - "6818:6818"
-        cap_add:
-            - SYS_PTRACE
-            - SYS_ADMIN
-            - MKNOD
-            - SYS_NICE
-            - SYS_RESOURCE
-        security_opt:
-            - seccomp:unconfined
-            - apparmor:unconfined
-        volumes:
-            - slurmd-lib-volume:/var/lib/slurmd
-            - slurmd-spool-volume:/var/spool/slurm
-            - slurmd-log-volume:/var/log/slurm
-            - slurmd-db-volume:/var/lib/mysql
-            - slurmd-jwt-volume:/etc/slurm/jwt
-        env_file:
-            - uqle.env
-        environment:
-            - NODE_TYPE=worker
+  slurmctl:
+    build: .
+    image: drew-docker-centos7-slurm:latest
+    hostname: slurmctl
+    stdin_open: true
+    tty: true
+    ports:
+      - "6819:6819"
+      - "6820:6820"
+    cap_add:
+      - SYS_PTRACE
+      - SYS_ADMIN
+      - MKNOD
+      - SYS_NICE
+      - SYS_RESOURCE
+    security_opt:
+      - seccomp:unconfined
+      - apparmor:unconfined
+    volumes:
+      - slurmctl-lib-volume:/var/lib/slurmd
+      - slurmctl-spool-volume:/var/spool/slurm
+      - slurmctl-log-volume:/var/log/slurm
+      - slurmctl-db-volume:/var/lib/mysql
+      - slurmctl-jwt-volume:/etc/slurm/jwt
+      - slurm-workdir-volume:/home/slurmrestd/shared
+    environment:
+      NODE_TYPE: controller
+      SLURM_JWT_KEY:
+  slurmd:
+    build: .
+    image: drew-docker-centos7-slurm:latest
+    hostname: slurmd
+    stdin_open: true
+    tty: true
+    ports:
+      - "6818:6818"
+    cap_add:
+      - SYS_PTRACE
+      - SYS_ADMIN
+      - MKNOD
+      - SYS_NICE
+      - SYS_RESOURCE
+    security_opt:
+      - seccomp:unconfined
+      - apparmor:unconfined
+    volumes:
+      - slurmd-lib-volume:/var/lib/slurmd
+      - slurmd-spool-volume:/var/spool/slurm
+      - slurmd-log-volume:/var/log/slurm
+      - slurmd-db-volume:/var/lib/mysql
+      - slurmd-jwt-volume:/etc/slurm/jwt
+      - slurm-workdir-volume:/home/slurmrestd/shared
+    environment:
+      NODE_TYPE: worker
+      SLURM_JWT_KEY:
 volumes:
-    slurmctl-db-volume:
-        name: "slurmctl-db-volume"
-    slurmctl-log-volume:
-        name: "slurmctl-log-volume"
-    slurmctl-spool-volume:
-        name: "slurmctl-spool-volume"
-    slurmctl-lib-volume:
-        name: "slurmctl-lib-volume"
-    slurmctl-jwt-volume:
-        name: "slurmctl-jwt-volume"
-    slurmd-db-volume:
-        name: "slurmd-db-volume"
-    slurmd-log-volume:
-        name: "slurmd-log-volume"
-    slurmd-spool-volume:
-        name: "slurmd-spool-volume"
-    slurmd-lib-volume:
-        name: "slurmd-lib-volume"
-    slurmd-jwt-volume:
-        name: "slurmd-jwt-volume"
+  slurmctl-db-volume:
+  slurmctl-log-volume:
+  slurmctl-spool-volume:
+  slurmctl-lib-volume:
+  slurmctl-jwt-volume:
+  slurmd-db-volume:
+  slurmd-log-volume:
+  slurmd-spool-volume:
+  slurmd-lib-volume:
+  slurmd-jwt-volume:
+  slurm-workdir-volume:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -41,18 +41,18 @@ function start_service {
     check_running_status $1
 }
 
-jwt_secret_file="/etc/slurm/jwt/jwt_hs256.key"
-if [ "$JWT_SECRET" ]
+jwt_key_file="/etc/slurm/jwt/jwt_hs256.key"
+if [ "$SLURM_JWT_KEY" ]
 then
     echo "- JWT secret variable found, writing..."
-    echo "$JWT_SECRET" > $jwt_secret_file
+    echo "$SLURM_JWT_KEY" > $jwt_key_file
 else
-    echo "- No JWT secret variable found, generating JWT key"
-    dd if=/dev/urandom bs=32 count=1 >$jwt_secret_file
+    echo "Error: JWT key not present in environment - aborting cluster deployment" >&2
+    exit 1
 fi
 
-chown slurm:slurm $jwt_secret_file
-chmod 0600 $jwt_secret_file
+chown slurm:slurm $jwt_key_file
+chmod 0600 $jwt_key_file
 
 if [[ "$NODE_TYPE" == "controller" ]]
 then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -41,9 +41,12 @@ function start_service {
     check_running_status $1
 }
 
-jwt_key_file="/etc/slurm/jwt/jwt_hs256.key"
+jwt_key_dir=/etc/slurm/jwt
+jwt_key_file=$jwt_key_dir/jwt_hs256.key
+
 if [ "$SLURM_JWT_KEY" ]
 then
+    mkdir -p $jwt_key_dir
     echo "- JWT secret variable found, writing..."
     echo -n "$SLURM_JWT_KEY" > $jwt_key_file
 else

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -45,7 +45,7 @@ jwt_key_file="/etc/slurm/jwt/jwt_hs256.key"
 if [ "$SLURM_JWT_KEY" ]
 then
     echo "- JWT secret variable found, writing..."
-    echo "$SLURM_JWT_KEY" > $jwt_key_file
+    echo -n "$SLURM_JWT_KEY" > $jwt_key_file
 else
     echo "Error: JWT key not present in environment - aborting cluster deployment" >&2
     exit 1


### PR DESCRIPTION
Abort running cluster if env var for JWT key isn't provided, as API now has env var added