### PR TITLE
GitHub actions deploy

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -30,9 +30,9 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       # Suffix tags for general pushes with '-dev'
-      - name: Assign dev tag suffix
-        if: ${{ github.ref != 'refs/heads/main'}}
-        run: echo "tag_suffix=-dev" >> $GITHUB_ENV
+      # - name: Assign dev tag suffix
+      #   if: ${{ github.ref != 'refs/heads/main'}}
+      #   run: echo "tag_suffix=-dev" >> $GITHUB_ENV
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -42,10 +42,11 @@ jobs:
           flavor: |
             latest=true
             suffix=${{ env.tag_suffix }},onlatest=true
+            prefix=${{ env.SLURM_TAG }},onlatest=true
           tags: |
-            type=raw,value=${{ env.SLURM_TAG }}
-            type=sha,suffix=
-            type=sha,format=long,suffix=
+            type=raw,value=
+            type=sha,suffix=,prefix=
+            type=sha,format=long,suffix=,prefix=
 
       - name: Log in to the Container registry
         uses: docker/login-action@v1

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -1,0 +1,65 @@
+name: Slurm cluster - Build and publish Docker image
+
+on:
+  push:
+    # branches:
+    #   - main
+    #   - dev
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/docker-centos7-slurm
+  SLURM_TAG: slurm-21-08-0-1
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      # Suffix tags for general pushes with '-dev'
+      # - name: Assign dev tag suffix
+      #   if: ${{ github.ref != 'refs/heads/main'}}
+      #   run: echo "tag_suffix=-dev" >> $GITHUB_ENV
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=${{ env.tag_suffix }},onlatest=true
+          tags: |
+            type=raw,value=${{ env.SLURM_TAG }}
+            type=sha,suffix=
+            type=sha,format=long,suffix=
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          build-args: |
+            SLURM_TAG=${{ env.SLURM_TAG }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -42,9 +42,8 @@ jobs:
           flavor: |
             latest=true
             suffix=${{ env.tag_suffix }},onlatest=true
-            prefix=${{ env.SLURM_VERSION }},onlatest=true
+            prefix=${{ env.SLURM_VERSION }}-,onlatest=true
           tags: |
-            type=raw,value=-
             type=sha,suffix=,prefix=
             type=sha,format=long,suffix=,prefix=
 

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      Suffix tags for general pushes with '-dev'
+      # Suffix tags for general pushes with '-dev'
       - name: Assign dev tag suffix
         if: ${{ github.ref != 'refs/heads/main'}}
         run: echo "tag_suffix=-dev" >> $GITHUB_ENV

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -40,10 +40,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
-            suffix=:latest${{ env.tag_suffix }},onlatest=true
-            suffix=${{ env.tag_suffix }},onlatest=false
+            latest=true
+            suffix=${{ env.tag_suffix }},onlatest=true
           tags: |
-            type=raw,value=${{ env.SLURM_TAG }}
             type=raw,value=${{ env.SLURM_TAG }}
             type=sha,suffix=
             type=sha,format=long,suffix=

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -9,7 +9,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/docker-centos7-slurm
-  SLURM_TAG: slurm-21-08-0-1
+  SLURM_VERSION: 21-08-0-1
 
 jobs:
   build-and-push-image:
@@ -42,9 +42,9 @@ jobs:
           flavor: |
             latest=true
             suffix=${{ env.tag_suffix }},onlatest=true
-            prefix=${{ env.SLURM_TAG }},onlatest=true
+            prefix=${{ env.SLURM_VERSION }},onlatest=true
           tags: |
-            type=raw,value=
+            type=raw,value=-
             type=sha,suffix=,prefix=
             type=sha,format=long,suffix=,prefix=
 
@@ -60,7 +60,7 @@ jobs:
         with:
           push: true
           build-args: |
-            SLURM_TAG=${{ env.SLURM_TAG }}
+            SLURM_TAG=slurm-${{ env.SLURM_VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      # Suffix tags for general pushes with '-dev'
-      # - name: Assign dev tag suffix
-      #   if: ${{ github.ref != 'refs/heads/main'}}
-      #   run: echo "tag_suffix=-dev" >> $GITHUB_ENV
+      Suffix tags for general pushes with '-dev'
+      - name: Assign dev tag suffix
+        if: ${{ github.ref != 'refs/heads/main'}}
+        run: echo "tag_suffix=-dev" >> $GITHUB_ENV
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -40,8 +40,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
-            suffix=${{ env.tag_suffix }},onlatest=true
+            suffix=:latest${{ env.tag_suffix }},onlatest=true
+            suffix=${{ env.tag_suffix }},onlatest=false
           tags: |
+            type=raw,value=${{ env.SLURM_TAG }}
             type=raw,value=${{ env.SLURM_TAG }}
             type=sha,suffix=
             type=sha,format=long,suffix=

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -30,9 +30,9 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       # Suffix tags for general pushes with '-dev'
-      # - name: Assign dev tag suffix
-      #   if: ${{ github.ref != 'refs/heads/main'}}
-      #   run: echo "tag_suffix=-dev" >> $GITHUB_ENV
+      - name: Assign dev tag suffix
+        if: ${{ github.ref != 'refs/heads/main'}}
+        run: echo "tag_suffix=-dev" >> $GITHUB_ENV
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -2,9 +2,9 @@ name: Slurm cluster - Build and publish Docker image
 
 on:
   push:
-    # branches:
-    #   - main
-    #   - dev
+    branches:
+      - main
+      - dev
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Working Github action to deploy cluster image to ghcr.io
- Image is tagged with version tag of the slurm version being built
- `-latest` or `-latest-dev` tag suffix is added automatically
